### PR TITLE
Add rate limiting to the public /mail/appointment endpoint

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -31,5 +31,5 @@ Route::get('privacyverklaring', function() {
 })->name('privacy');
 
 Route::post('/mail/appointment', [AppointmentController::class, 'index'])
-    ->middleware(ProtectAgainstSpam::class)
+    ->middleware([ProtectAgainstSpam::class, 'throttle:5,1'])
     ->name('mail.appointment');

--- a/tests/Feature/AppointmentControllerTest.php
+++ b/tests/Feature/AppointmentControllerTest.php
@@ -99,6 +99,21 @@ class AppointmentControllerTest extends TestCase
         Mail::assertNothingSent();
     }
 
+    public function testSixthSubmissionWithinOneMinuteIsRateLimited()
+    {
+        Mail::fake();
+
+        for ($i = 0; $i < 5; $i++) {
+            $response = $this->post('/mail/appointment', $this->validPayload());
+            $response->assertRedirect('/');
+        }
+
+        $response = $this->post('/mail/appointment', $this->validPayload());
+
+        $response->assertStatus(429);
+        Mail::assertSent(AppointmentMail::class, 10);
+    }
+
     public function testMissingMessageIsOptionalAndSucceeds()
     {
         Mail::fake();


### PR DESCRIPTION
## TLDR
Rate limit the public appointment mail endpoint. Changed 2 file(s): +16/-1 lines.

## Plan
1) In routes/web.php, add a throttle middleware to the existing route: change `->middleware(ProtectAgainstSpam::class)` to `->middleware([ProtectAgainstSpam::class, 'throttle:5,1'])` (5 requests/min is generous for a contact form; adjust if a config value is preferred). 2) Add a new test method to tests/Feature/AppointmentControllerTest.php, following the existing validPayload()/Mail::fake() pattern: submit the valid payload 6 times in a loop within the same test and assert the 6th response has status 429, and that Mail::assertSent(AppointmentMail::class, 10) (5 valid submissions × 2 sends each) to confirm the limiter — not validation — is what blocked the 6th. 3) Run `php artisan test --filter=AppointmentControllerTest` (or vendor/bin/phpunit) to confirm the new test passes and the existing tests are unaffected.

---
*Generated by Claude Runner*