### PR TITLE
Remove unauthenticated debug phpinfo() route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -24,7 +24,6 @@ Route::get('/tarieven', [HomeController::class, 'tarieven'])->name('tarieven');
 Route::get('/contact', [HomeController::class, 'contact'])->name('contact');
 
 //Auth::routes();
-Route::get('phpinfo', fn() => phpinfo());
 
 Route::get('privacyverklaring', function() {
     return redirect()->to('/assets/documents/privacyverklaring.pdf');

--- a/tests/Feature/DebugRoutesTest.php
+++ b/tests/Feature/DebugRoutesTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class DebugRoutesTest extends TestCase
+{
+    public function testPhpinfoRouteIsNotRegistered()
+    {
+        $response = $this->get('/phpinfo');
+
+        $response->assertStatus(404);
+    }
+}


### PR DESCRIPTION
## TLDR
Remove unauthenticated phpinfo() debug route. Changed 2 file(s): +15/-1 lines.

## Plan
Delete line 27 (`Route::get('phpinfo', fn() => phpinfo());`) from routes/web.php. Add a Feature test in tests/Feature (e.g. tests/Feature/DebugRoutesTest.php) asserting `$this->get('/phpinfo')->assertStatus(404)` to prevent regression. Run `php artisan route:list` mentally/via test to confirm no other code references the 'phpinfo' route name (grep shows none).

---
*Generated by Claude Runner*