### PR TITLE
Fix broken honeypot 'amount_of_seconds' env key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,9 @@ MAIL_ENCRYPTION=null
 MAIL_FROM_ADDRESS=null
 MAIL_FROM_NAME="${APP_NAME}"
 
+# Minimum seconds a form must be on screen before submission is accepted
+HONEYPOT_SECONDS=1
+
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_DEFAULT_REGION=us-east-1

--- a/config/honeypot.php
+++ b/config/honeypot.php
@@ -28,7 +28,7 @@ return [
      * If the form is submitted faster than this amount of seconds
      * the form submission will be considered invalid.
      */
-    'amount_of_seconds' => env('php artisan vendor:publish --provider="Spatie\Honeypot\HoneypotServiceProvider" --tag=config', 1),
+    'amount_of_seconds' => env('HONEYPOT_SECONDS', 1),
 
     /*
      * This class is responsible for sending a response to requests that

--- a/tests/Unit/HoneypotConfigTest.php
+++ b/tests/Unit/HoneypotConfigTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+
+class HoneypotConfigTest extends TestCase
+{
+    private const ENV_KEY = 'HONEYPOT_SECONDS';
+
+    private const DEFAULT_SECONDS = 1;
+
+    private const OVERRIDE_SECONDS = '5';
+
+    protected function tearDown(): void
+    {
+        putenv(self::ENV_KEY);
+
+        parent::tearDown();
+    }
+
+    public function testAmountOfSecondsDefaultsToOne()
+    {
+        $this->assertSame(self::DEFAULT_SECONDS, config('honeypot.amount_of_seconds'));
+    }
+
+    public function testAmountOfSecondsIsReadFromTheEnvironment()
+    {
+        putenv(self::ENV_KEY . '=' . self::OVERRIDE_SECONDS);
+
+        $config = require config_path('honeypot.php');
+
+        $this->assertSame(self::OVERRIDE_SECONDS, $config['amount_of_seconds']);
+    }
+}


### PR DESCRIPTION
## TLDR
Fix broken honeypot amount_of_seconds env key. Changed 3 file(s): +39/-1 lines.

## Plan
In config/honeypot.php:31, replace the env key with a proper variable name consistent with the other entries in the same file (e.g. 'HONEYPOT_SECONDS'), matching the pattern used at lines 11, 18, 25, 52: `'amount_of_seconds' => env('HONEYPOT_SECONDS', 1),`. Add the new HONEYPOT_SECONDS key to .env.example alongside a sensible default comment. Add a Unit test (tests/Unit/HoneypotConfigTest.php) that asserts `config('honeypot.amount_of_seconds') === 1` by default, and, using `putenv`/`Config::set` or an .env override in a second test, that the value is honored when HONEYPOT_SECONDS is set.

---
*Generated by Claude Runner*