### PR TITLE
Fallback path when the Salonized booking widget doesn't load

### DIFF
--- a/resources/views/components/appointment-fallback.blade.php
+++ b/resources/views/components/appointment-fallback.blade.php
@@ -1,0 +1,61 @@
+<section class="px-4 py-16 sm:px-6 lg:px-8" id="afspraak-formulier" data-booking-fallback {{ $errors->any() ? '' : 'hidden' }}>
+    <div class="mx-auto w-full max-w-3xl rounded-3xl border border-brand-100 bg-white p-6 shadow-sm lg:p-10">
+        <span class="section-kicker"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="16" x="2" y="4" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg> Afspraak</span>
+        <h2 class="section-title">Afspraak aanvragen</h2>
+        <p class="mt-4 text-base text-gray-600">Het online boekingsysteem kon niet worden geladen. Laat hieronder uw gegevens achter, dan nemen wij contact met u op.</p>
+
+        @if ($errors->any())
+            <ul class="mt-6 space-y-2 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-base text-amber-900">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        @endif
+
+        <form class="mt-6 space-y-4" method="POST" action="{{ route('mail.appointment') }}">
+            @csrf
+            @honeypot
+
+            <div class="grid gap-6 md:grid-cols-2">
+                <label class="block">
+                    <span class="text-base font-medium text-gray-900">Naam</span>
+                    <input class="mt-1 w-full rounded-xl border border-brand-100 px-4 py-3 text-base text-gray-900" type="text" name="name" value="{{ old('name') }}" minlength="2" maxlength="50" required>
+                </label>
+
+                <label class="block">
+                    <span class="text-base font-medium text-gray-900">E-mailadres</span>
+                    <input class="mt-1 w-full rounded-xl border border-brand-100 px-4 py-3 text-base text-gray-900" type="email" name="email" value="{{ old('email') }}" minlength="5" maxlength="100" required>
+                </label>
+
+                <label class="block">
+                    <span class="text-base font-medium text-gray-900">Behandeling</span>
+                    <select class="mt-1 w-full rounded-xl border border-brand-100 px-4 py-3 text-base text-gray-900" name="procedure" required>
+                        <option value="" disabled @if (! old('procedure')) selected @endif>Selecteer behandeling</option>
+                        <option value="pedicure" @if (old('procedure') === 'pedicure') selected @endif>Pedicure</option>
+                        <option value="spabehandeling" @if (old('procedure') === 'spabehandeling') selected @endif>Spabehandeling</option>
+                    </select>
+                </label>
+
+                <label class="block">
+                    <span class="text-base font-medium text-gray-900">Telefoonnummer</span>
+                    <input class="mt-1 w-full rounded-xl border border-brand-100 px-4 py-3 text-base text-gray-900" type="tel" name="phone" value="{{ old('phone') }}" minlength="5" maxlength="25" required>
+                </label>
+            </div>
+
+            <label class="block">
+                <span class="text-base font-medium text-gray-900">Opmerking</span>
+                <textarea class="mt-1 w-full rounded-xl border border-brand-100 px-4 py-3 text-base text-gray-900" name="message" rows="4" maxlength="350">{{ old('message') }}</textarea>
+            </label>
+
+            <label class="flex items-center gap-3 text-base text-gray-600">
+                <input class="h-4 w-4" type="checkbox" name="opt_in" value="1" required>
+                <span>Ik ga akkoord met de <a class="text-brand-700" target="_blank" href="{{ route('privacy') }}">privacyverklaring</a>.</span>
+            </label>
+
+            <div class="flex flex-wrap gap-3">
+                <button class="brand-btn" type="submit">Versturen</button>
+                <a class="brand-btn-outline" href="tel:0544-373326">Of bel: 0544-373326</a>
+            </div>
+        </form>
+    </div>
+</section>

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -16,6 +16,7 @@
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700&family=Manrope:wght@400;500;600;700&display=swap"></noscript>
     <link rel="preload" href="{{ mix('/css/app.css') }}" as="style">
     <link rel="stylesheet" type="text/css" href="{{ mix('/css/app.css') }}">
+    <noscript><style>[data-booking-fallback][hidden] { display: block !important; }</style></noscript>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-NG5XWRCFNG"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
@@ -37,13 +38,59 @@
 
     <main>
         @yield('content')
+
+        @include('components.appointment-fallback')
     </main>
 
     @include('components.footer')
 </div>
 
 <div class="salonized-booking" data-company="avMXRDrsiQtTjmmxqfcCpTpk" data-color="#4f9fb8" data-language="nl" data-outline="shadow"></div>
+<script>
+    (function () {
+        var FALLBACK_DELAY_MS = 8000;
+        var revealed = false;
+
+        function widgetHasRendered() {
+            var widget = document.querySelector('.salonized-booking');
+
+            return !!widget && widget.children.length > 0;
+        }
+
+        function revealFallback() {
+            if (revealed) {
+                return;
+            }
+
+            revealed = true;
+
+            var fallback = document.getElementById('afspraak-formulier');
+
+            if (!fallback) {
+                return;
+            }
+
+            fallback.removeAttribute('hidden');
+
+            var ctas = document.querySelectorAll('a[href="#sz-booking-open"]');
+
+            for (var i = 0; i < ctas.length; i++) {
+                ctas[i].setAttribute('href', '#afspraak-formulier');
+            }
+        }
+
+        window.salonizedWidgetFailed = revealFallback;
+
+        window.addEventListener('load', function () {
+            window.setTimeout(function () {
+                if (!widgetHasRendered()) {
+                    revealFallback();
+                }
+            }, FALLBACK_DELAY_MS);
+        });
+    })();
+</script>
 <script defer src="{{ mix('/js/app.js') }}"></script>
-<script defer src="https://static-widget.salonized.com/loader.js"></script>
+<script defer src="https://static-widget.salonized.com/loader.js" onerror="window.salonizedWidgetFailed()"></script>
 </body>
 </html>

--- a/tests/Feature/AppointmentFallbackTest.php
+++ b/tests/Feature/AppointmentFallbackTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class AppointmentFallbackTest extends TestCase
+{
+    private const FALLBACK_ID = 'id="afspraak-formulier"';
+
+    public function testHomepageRendersTheFallbackFormHiddenByDefault()
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+        $response->assertSee(self::FALLBACK_ID, false);
+        $response->assertSee('data-booking-fallback hidden', false);
+        $response->assertSee('action="' . route('mail.appointment') . '"', false);
+        $response->assertSee('name="_token"', false);
+    }
+
+    public function testContactPageRendersTheFallbackForm()
+    {
+        $response = $this->get('/contact');
+
+        $response->assertStatus(200);
+        $response->assertSee(self::FALLBACK_ID, false);
+        $response->assertSee('action="' . route('mail.appointment') . '"', false);
+    }
+
+    public function testEveryPageShipsTheWidgetFailureDetectionScript()
+    {
+        $response = $this->get('/');
+
+        $response->assertSee('onerror="window.salonizedWidgetFailed()"', false);
+        $response->assertSee('[data-booking-fallback][hidden] { display: block !important; }', false);
+    }
+
+    public function testFallbackFormIsRevealedWhenSubmissionFailsValidation()
+    {
+        Mail::fake();
+
+        $this->from('/')->post('/mail/appointment', ['name' => '']);
+
+        $response = $this->get('/');
+
+        $response->assertSee(self::FALLBACK_ID, false);
+        $response->assertDontSee('data-booking-fallback hidden', false);
+    }
+}


### PR DESCRIPTION
## TLDR
Add fallback appointment form when Salonized widget fails to load. Changed 3 file(s): +160/-1 lines.

## Plan
**Problem.** master.blade.php:45-47 wires every 'Afspraak maken' CTA site-wide (navbar, footer, homepage banner, homepage appointments section, contact page) to href="#sz-booking-open", which only does anything once the third-party script static-widget.salonized.com/loader.js finishes executing. There's no <noscript> or load-failure fallback for it — unlike the Google Fonts preload two lines above it, which does have one. Meanwhile the app already contains a fully working server-side appointment intake (AppointmentController, AppointmentRequest, AppointmentMail, route mail.appointment) that no current view links to — it's built but orphaned since the site moved to Salonized.

**Outcome.** A visitor whose browser blocks or fails to load the third-party widget can still reach Edith through a form the app already knows how to handle, instead of every CTA on the site becoming a dead '#' link.

**Sketch.** Detect widget load failure (script onerror + short timeout on the loader) and reveal the existing, currently-unused appointment form as a fallback in place of the dead anchor. Touches a couple of blade partials (navbar/footer CTA, a resurfaced form partial); no backend changes since the controller/request/mailable already work end-to-end. Main risk: false positives flashing the fallback to users where the widget is just loading slowly — needs a sane timeout, not a hair-trigger one.

---
*Generated by Claude Runner*