### PR TITLE
Let Edith manage her own treatment & spa content

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,10 @@ MAIL_FROM_NAME="${APP_NAME}"
 # Minimum seconds a form must be on screen before submission is accepted
 HONEYPOT_SECONDS=1
 
+# Credentials for the /admin user seeded by UserSeeder
+ADMIN_EMAIL=edith@bijedith.nl
+ADMIN_PASSWORD=
+
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_DEFAULT_REGION=us-east-1

--- a/app/Http/Controllers/Admin/TreatmentController.php
+++ b/app/Http/Controllers/Admin/TreatmentController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\TreatmentRequest;
+use App\Treatment;
+use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class TreatmentController extends Controller
+{
+    public function index(): Renderable
+    {
+        $treatments = Treatment::orderBy('category')->orderBy('id')->get();
+
+        return view('admin.treatments.index', compact('treatments'));
+    }
+
+    public function create(): Renderable
+    {
+        return view('admin.treatments.create');
+    }
+
+    public function store(TreatmentRequest $request): RedirectResponse
+    {
+        $attributes = $request->safe()->only(['category', 'name', 'description']);
+        [$attributes['image'], $attributes['webp_image']] = $this->storeImage($request->file('image'));
+
+        Treatment::create($attributes);
+
+        return redirect()->route('admin.treatments.index')->with('success', 'Behandeling toegevoegd.');
+    }
+
+    public function edit(Treatment $treatment): Renderable
+    {
+        return view('admin.treatments.edit', compact('treatment'));
+    }
+
+    public function update(TreatmentRequest $request, Treatment $treatment): RedirectResponse
+    {
+        $attributes = $request->safe()->only(['category', 'name', 'description']);
+
+        if ($request->hasFile('image')) {
+            [$attributes['image'], $attributes['webp_image']] = $this->storeImage($request->file('image'));
+        }
+
+        $treatment->update($attributes);
+
+        return redirect()->route('admin.treatments.index')->with('success', 'Behandeling bijgewerkt.');
+    }
+
+    public function destroy(Treatment $treatment): RedirectResponse
+    {
+        $treatment->delete();
+
+        return redirect()->route('admin.treatments.index')->with('success', 'Behandeling verwijderd.');
+    }
+
+    /**
+     * Stores the uploaded image alongside a webp copy, matching the
+     * existing public/assets/pictures (+ webp/) convention the templates rely on.
+     *
+     * @return array{0: string, 1: string}
+     */
+    private function storeImage(UploadedFile $file): array
+    {
+        $extension = $file->extension();
+        $filename = Str::uuid() . '.' . $extension;
+        $webpFilename = Str::uuid() . '.webp';
+
+        Storage::disk('treatment_images')->putFileAs('', $file, $filename);
+
+        $source = match ($extension) {
+            'png'         => imagecreatefrompng(Storage::disk('treatment_images')->path($filename)),
+            'jpg', 'jpeg' => imagecreatefromjpeg(Storage::disk('treatment_images')->path($filename)),
+            default       => null,
+        };
+
+        if ($source !== null) {
+            imagewebp($source, Storage::disk('treatment_images_webp')->path($webpFilename));
+            imagedestroy($source);
+        }
+
+        return [
+            '/assets/pictures/' . $filename,
+            '/assets/pictures/webp/' . $webpFilename,
+        ];
+    }
+}

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Providers\RouteServiceProvider;
+use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class LoginController extends Controller
+{
+    public function showLoginForm(): Renderable
+    {
+        return view('auth.login');
+    }
+
+    public function login(Request $request): RedirectResponse
+    {
+        $credentials = $request->validate([
+            'email'    => 'required|email',
+            'password' => 'required',
+        ]);
+
+        if (! Auth::attempt($credentials, $request->boolean('remember'))) {
+            return back()
+                ->withInput($request->only('email'))
+                ->withErrors(['email' => 'Deze combinatie van e-mailadres en wachtwoord is niet bekend.']);
+        }
+
+        $request->session()->regenerate();
+
+        return redirect()->intended(RouteServiceProvider::HOME);
+    }
+
+    public function logout(Request $request): RedirectResponse
+    {
+        Auth::logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect()->route('login');
+    }
+}

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Treatment;
 use Illuminate\Contracts\Support\Renderable;
 
 class HomeController extends Controller
@@ -13,68 +14,18 @@ class HomeController extends Controller
 
     public function behandelingen(): Renderable
     {
-        $pedicureprocedures = collect([
-            [
-                'img'         => '/assets/pictures/DCM_9932-pichi.png',
-                'webp_img'    => '/assets/pictures/webp/DCM_9932-pichi.webp',
-                'name'        => 'Pedicurebehandeling',
-                'description' => '
-            <ul class="content-list">
-                <li>Wassen en desinfecteren van de voeten voor optimale hygiëne</li>
-                <li>Knippen van de nagels</li>
-                <li>De verzorging van de nagels en de nagelomgeving</li>
-                <li>Het verwijderen van overtollig eelt</li>
-                <li>Het verwijderen van likdoorns</li>
-                <li>De behandeling van kloven</li>
-                <li>De behandeling van schimmelnagels en ingroeiende nagels</li>
-                <li>Verzorgen van de voeten met voedende crème</li>
-            </ul>',
-            ],
-            [
-                'img'         => '/assets/pictures/DF2_2051-pichi.png',
-                'webp_img'    => '/assets/pictures/webp/DF2_2051-pichi.webp',
-                'name'        => 'Gespecialiseerde pedicurebehandeling',
-                'description' => 'Mensen kunnen door hun ziektegeschiedenis een verhoogd risico hebben op voetproblemen.<br/><br/>
-
-Voorkomen, op tijd signaleren en behandelen van voetproblemen is belangrijk voor de mobiliteit en kwaliteit van het leven.<br/><br/>
-
-Waar nodig wordt door Edith als Medisch Pedicure samenwerking gezocht met andere disciplines, zoals huisarts, de podotherapeut, fysiotherapeut of orthopedisch schoenmaker.',
-            ],
-        ]);
+        $pedicureprocedures = Treatment::where('category', Treatment::CATEGORY_BEHANDELING)
+            ->orderBy('id')
+            ->get();
 
         return view('pages.behandelingen', compact('pedicureprocedures'));
     }
 
     public function spaArrangementen(): Renderable
     {
-        $spaprocedures = collect([
-            [
-                'img'         => '/assets/pictures/DCM_9970-pichi.png',
-                'webp_img'    => '/assets/pictures/webp/DCM_9970-pichi.webp',
-                'name'        => 'Klassieke Voet- en onderbeen massage',
-                'description' => 'Deze stevige massage van ongeveer 30 minuten zorgt ervoor dat de spieren in jouw onderbeen en voeten weer soepel aanvoelen.<br/><br/>
-Massage geeft nieuwe energie, rust en ontspanning.',
-            ],
-            [
-                'img'         => '/assets/pictures/DCM_9982-pichi.png',
-                'webp_img'    => '/assets/pictures/webp/DCM_9982-pichi.webp',
-                'name'        => 'Sparkling-arrangement',
-                'description' => 'Een luxe verwenbehandeling samen met een uitverkorene (zus, vriendin, moeder of dochter).<br/><br/>
-Koffie/thee/drankje en lekkernijen horen hier natuurlijk bij!',
-            ],
-            [
-                'img'         => '/assets/pictures/DF2_2060-pichi.png',
-                'webp_img'    => '/assets/pictures/webp/DF2_2060-pichi.webp',
-                'name'        => 'In overleg mogelijk',
-                'description' => '<ul class="content-list">
-            <li>Voetbad met Hydro massage</li>
-            <li>Scrub-behandeling</li>
-            <li>Nagelverzorging</li>
-            <li>Voetmassage</li>
-            <li>Nagels lakken</li>
-</ul>',
-            ],
-        ]);
+        $spaprocedures = Treatment::where('category', Treatment::CATEGORY_SPA)
+            ->orderBy('id')
+            ->get();
 
         return view('pages.spa-arrangementen', compact('spaprocedures'));
     }

--- a/app/Http/Requests/TreatmentRequest.php
+++ b/app/Http/Requests/TreatmentRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Treatment;
+use Illuminate\Foundation\Http\FormRequest;
+
+class TreatmentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $imageRule = $this->isMethod('post') ? 'required' : 'nullable';
+
+        return [
+            'category'    => 'required|in:' . Treatment::CATEGORY_BEHANDELING . ',' . Treatment::CATEGORY_SPA,
+            'name'        => 'required|max:100',
+            'description' => 'required|max:2000',
+            'image'       => $imageRule . '|image|mimes:png,jpg,jpeg|max:5120',
+        ];
+    }
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -21,7 +21,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/home';
+    public const HOME = '/admin/treatments';
 
     /**
      * Define your route model bindings, pattern filters, etc.

--- a/app/Treatment.php
+++ b/app/Treatment.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Treatment extends Model
+{
+    public const CATEGORY_BEHANDELING = 'behandeling';
+    public const CATEGORY_SPA = 'spa';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'category', 'name', 'description', 'image', 'webp_image',
+    ];
+}

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -65,6 +65,20 @@ return [
             'endpoint' => env('AWS_ENDPOINT'),
         ],
 
+        'treatment_images' => [
+            'driver' => 'local',
+            'root' => public_path('assets/pictures'),
+            'url' => '/assets/pictures',
+            'visibility' => 'public',
+        ],
+
+        'treatment_images_webp' => [
+            'driver' => 'local',
+            'root' => public_path('assets/pictures/webp'),
+            'url' => '/assets/pictures/webp',
+            'visibility' => 'public',
+        ],
+
     ],
 
     /*

--- a/database/migrations/2026_08_04_000001_create_treatments_table.php
+++ b/database/migrations/2026_08_04_000001_create_treatments_table.php
@@ -1,0 +1,112 @@
+<?php
+
+use App\Treatment;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('treatments', function (Blueprint $table) {
+            $table->id();
+            $table->string('category');
+            $table->string('name');
+            $table->text('description');
+            $table->string('image');
+            $table->string('webp_image');
+            $table->timestamps();
+        });
+
+        $this->seedExistingContent();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('treatments');
+    }
+
+    /**
+     * Carries over the treatments and spa packages that previously lived as
+     * hardcoded arrays in HomeController, so existing content survives the move.
+     *
+     * @return void
+     */
+    private function seedExistingContent()
+    {
+        $rows = [
+            [
+                'category'    => Treatment::CATEGORY_BEHANDELING,
+                'image'       => '/assets/pictures/DCM_9932-pichi.png',
+                'webp_image'  => '/assets/pictures/webp/DCM_9932-pichi.webp',
+                'name'        => 'Pedicurebehandeling',
+                'description' => '
+            <ul class="content-list">
+                <li>Wassen en desinfecteren van de voeten voor optimale hygiëne</li>
+                <li>Knippen van de nagels</li>
+                <li>De verzorging van de nagels en de nagelomgeving</li>
+                <li>Het verwijderen van overtollig eelt</li>
+                <li>Het verwijderen van likdoorns</li>
+                <li>De behandeling van kloven</li>
+                <li>De behandeling van schimmelnagels en ingroeiende nagels</li>
+                <li>Verzorgen van de voeten met voedende crème</li>
+            </ul>',
+            ],
+            [
+                'category'    => Treatment::CATEGORY_BEHANDELING,
+                'image'       => '/assets/pictures/DF2_2051-pichi.png',
+                'webp_image'  => '/assets/pictures/webp/DF2_2051-pichi.webp',
+                'name'        => 'Gespecialiseerde pedicurebehandeling',
+                'description' => 'Mensen kunnen door hun ziektegeschiedenis een verhoogd risico hebben op voetproblemen.<br/><br/>
+
+Voorkomen, op tijd signaleren en behandelen van voetproblemen is belangrijk voor de mobiliteit en kwaliteit van het leven.<br/><br/>
+
+Waar nodig wordt door Edith als Medisch Pedicure samenwerking gezocht met andere disciplines, zoals huisarts, de podotherapeut, fysiotherapeut of orthopedisch schoenmaker.',
+            ],
+            [
+                'category'    => Treatment::CATEGORY_SPA,
+                'image'       => '/assets/pictures/DCM_9970-pichi.png',
+                'webp_image'  => '/assets/pictures/webp/DCM_9970-pichi.webp',
+                'name'        => 'Klassieke Voet- en onderbeen massage',
+                'description' => 'Deze stevige massage van ongeveer 30 minuten zorgt ervoor dat de spieren in jouw onderbeen en voeten weer soepel aanvoelen.<br/><br/>
+Massage geeft nieuwe energie, rust en ontspanning.',
+            ],
+            [
+                'category'    => Treatment::CATEGORY_SPA,
+                'image'       => '/assets/pictures/DCM_9982-pichi.png',
+                'webp_image'  => '/assets/pictures/webp/DCM_9982-pichi.webp',
+                'name'        => 'Sparkling-arrangement',
+                'description' => 'Een luxe verwenbehandeling samen met een uitverkorene (zus, vriendin, moeder of dochter).<br/><br/>
+Koffie/thee/drankje en lekkernijen horen hier natuurlijk bij!',
+            ],
+            [
+                'category'    => Treatment::CATEGORY_SPA,
+                'image'       => '/assets/pictures/DF2_2060-pichi.png',
+                'webp_image'  => '/assets/pictures/webp/DF2_2060-pichi.webp',
+                'name'        => 'In overleg mogelijk',
+                'description' => '<ul class="content-list">
+            <li>Voetbad met Hydro massage</li>
+            <li>Scrub-behandeling</li>
+            <li>Nagelverzorging</li>
+            <li>Voetmassage</li>
+            <li>Nagels lakken</li>
+</ul>',
+            ],
+        ];
+
+        foreach ($rows as $row) {
+            Treatment::create($row);
+        }
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UserSeeder::class);
+        $this->call(UserSeeder::class);
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Seed the admin user used to log in to /admin.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $password = env('ADMIN_PASSWORD');
+
+        if (! $password) {
+            $this->command->error('Set ADMIN_PASSWORD in your .env before running this seeder.');
+
+            return;
+        }
+
+        User::firstOrCreate(
+            ['email' => env('ADMIN_EMAIL', 'edith@bijedith.nl')],
+            ['name' => 'Edith', 'password' => Hash::make($password)]
+        );
+    }
+}

--- a/resources/views/admin/layout.blade.php
+++ b/resources/views/admin/layout.blade.php
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Beheer | Bij Edith</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="stylesheet" type="text/css" href="{{ mix('/css/app.css') }}">
+</head>
+<body class="bg-gray-50">
+<div class="min-h-screen">
+    @auth
+        <header class="border-b border-gray-200 bg-white px-4 py-4 sm:px-6 lg:px-8">
+            <div class="mx-auto flex w-full max-w-5xl items-center justify-between">
+                <a href="{{ route('admin.treatments.index') }}" class="text-lg font-display font-semibold text-bijedith-black">Beheer</a>
+                <form method="POST" action="{{ route('logout') }}">
+                    @csrf
+                    <button type="submit" class="text-sm text-gray-600 hover:text-bijedith-black">Uitloggen</button>
+                </form>
+            </div>
+        </header>
+    @endauth
+
+    <main class="px-4 py-10 sm:px-6 lg:px-8">
+        <div class="mx-auto w-full max-w-5xl">
+            @if (\Session::has('success'))
+                <div class="mb-6 rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">
+                    {{ \Session::get('success') }}
+                </div>
+            @endif
+
+            @yield('content')
+        </div>
+    </main>
+</div>
+</body>
+</html>

--- a/resources/views/admin/treatments/_form.blade.php
+++ b/resources/views/admin/treatments/_form.blade.php
@@ -1,0 +1,40 @@
+@csrf
+
+<div>
+    <label for="category" class="block text-sm font-medium text-gray-700">Categorie</label>
+    <select id="category" name="category" required class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm">
+        <option value="{{ \App\Treatment::CATEGORY_BEHANDELING }}" @selected(old('category', $treatment->category ?? '') === \App\Treatment::CATEGORY_BEHANDELING)>Behandeling</option>
+        <option value="{{ \App\Treatment::CATEGORY_SPA }}" @selected(old('category', $treatment->category ?? '') === \App\Treatment::CATEGORY_SPA)>Spa-arrangement</option>
+    </select>
+    @error('category')<p class="mt-1 text-sm text-red-600">{{ $message }}</p>@enderror
+</div>
+
+<div>
+    <label for="name" class="block text-sm font-medium text-gray-700">Naam</label>
+    <input id="name" type="text" name="name" value="{{ old('name', $treatment->name ?? '') }}" required
+           class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm">
+    @error('name')<p class="mt-1 text-sm text-red-600">{{ $message }}</p>@enderror
+</div>
+
+<div>
+    <label for="description" class="block text-sm font-medium text-gray-700">Beschrijving</label>
+    <textarea id="description" name="description" rows="6" required
+              class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm">{{ old('description', $treatment->description ?? '') }}</textarea>
+    <p class="mt-1 text-xs text-gray-500">HTML-opmaak zoals &lt;br&gt; en &lt;ul&gt; wordt ondersteund.</p>
+    @error('description')<p class="mt-1 text-sm text-red-600">{{ $message }}</p>@enderror
+</div>
+
+<div>
+    <label for="image" class="block text-sm font-medium text-gray-700">Foto (PNG of JPG)</label>
+    @isset($treatment)
+        <img src="{{ $treatment->image }}" alt="" class="my-2 h-24 w-24 rounded-lg object-cover">
+    @endisset
+    <input id="image" type="file" name="image" accept="image/png,image/jpeg"
+           class="mt-1 block w-full text-sm">
+    @error('image')<p class="mt-1 text-sm text-red-600">{{ $message }}</p>@enderror
+</div>
+
+<div class="flex items-center gap-4">
+    <button type="submit" class="brand-btn">Opslaan</button>
+    <a href="{{ route('admin.treatments.index') }}" class="text-sm text-gray-600 hover:underline">Annuleren</a>
+</div>

--- a/resources/views/admin/treatments/create.blade.php
+++ b/resources/views/admin/treatments/create.blade.php
@@ -1,0 +1,9 @@
+@extends('admin.layout')
+@section('content')
+    <h1 class="mb-6 text-2xl font-display font-semibold text-bijedith-black">Nieuwe behandeling</h1>
+
+    <form method="POST" action="{{ route('admin.treatments.store') }}" enctype="multipart/form-data"
+          class="max-w-xl space-y-4 rounded-2xl border border-brand-100 bg-white p-6">
+        @include('admin.treatments._form')
+    </form>
+@endsection

--- a/resources/views/admin/treatments/edit.blade.php
+++ b/resources/views/admin/treatments/edit.blade.php
@@ -1,0 +1,10 @@
+@extends('admin.layout')
+@section('content')
+    <h1 class="mb-6 text-2xl font-display font-semibold text-bijedith-black">Behandeling bewerken</h1>
+
+    <form method="POST" action="{{ route('admin.treatments.update', $treatment) }}" enctype="multipart/form-data"
+          class="max-w-xl space-y-4 rounded-2xl border border-brand-100 bg-white p-6">
+        @method('PUT')
+        @include('admin.treatments._form')
+    </form>
+@endsection

--- a/resources/views/admin/treatments/index.blade.php
+++ b/resources/views/admin/treatments/index.blade.php
@@ -1,0 +1,45 @@
+@extends('admin.layout')
+@section('content')
+    <div class="mb-6 flex items-center justify-between">
+        <h1 class="text-2xl font-display font-semibold text-bijedith-black">Behandelingen & spa-arrangementen</h1>
+        <a href="{{ route('admin.treatments.create') }}" class="brand-btn">Nieuwe toevoegen</a>
+    </div>
+
+    <div class="overflow-hidden rounded-2xl border border-brand-100 bg-white">
+        <table class="w-full text-left text-sm">
+            <thead class="border-b border-gray-200 bg-gray-50 text-gray-600">
+                <tr>
+                    <th class="px-4 py-3">Afbeelding</th>
+                    <th class="px-4 py-3">Naam</th>
+                    <th class="px-4 py-3">Categorie</th>
+                    <th class="px-4 py-3"></th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+                @forelse ($treatments as $treatment)
+                    <tr>
+                        <td class="px-4 py-3">
+                            <img src="{{ $treatment->image }}" alt="" class="h-12 w-12 rounded-lg object-cover">
+                        </td>
+                        <td class="px-4 py-3 font-medium text-bijedith-black">{{ $treatment->name }}</td>
+                        <td class="px-4 py-3 text-gray-600">
+                            {{ $treatment->category === \App\Treatment::CATEGORY_SPA ? 'Spa-arrangement' : 'Behandeling' }}
+                        </td>
+                        <td class="px-4 py-3 text-right">
+                            <a href="{{ route('admin.treatments.edit', $treatment) }}" class="text-bijedith-black hover:underline">Bewerken</a>
+                            <form method="POST" action="{{ route('admin.treatments.destroy', $treatment) }}" class="inline" onsubmit="return confirm('Weet je het zeker?')">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="ml-4 text-red-600 hover:underline">Verwijderen</button>
+                            </form>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="4" class="px-4 py-6 text-center text-gray-500">Nog geen behandelingen toegevoegd.</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+@endsection

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,0 +1,35 @@
+@extends('admin.layout')
+@section('content')
+    <div class="mx-auto max-w-sm rounded-2xl border border-brand-100 bg-white p-8 shadow-sm">
+        <h1 class="mb-6 text-2xl font-display font-semibold text-bijedith-black">Inloggen</h1>
+
+        @if ($errors->any())
+            <div class="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+                {{ $errors->first() }}
+            </div>
+        @endif
+
+        <form method="POST" action="{{ route('login') }}" class="space-y-4">
+            @csrf
+
+            <div>
+                <label for="email" class="block text-sm font-medium text-gray-700">E-mailadres</label>
+                <input id="email" type="email" name="email" value="{{ old('email') }}" required autofocus
+                       class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm">
+            </div>
+
+            <div>
+                <label for="password" class="block text-sm font-medium text-gray-700">Wachtwoord</label>
+                <input id="password" type="password" name="password" required
+                       class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm">
+            </div>
+
+            <label class="flex items-center gap-2 text-sm text-gray-600">
+                <input type="checkbox" name="remember">
+                Onthoud mij
+            </label>
+
+            <button type="submit" class="brand-btn w-full justify-center">Inloggen</button>
+        </form>
+    </div>
+@endsection

--- a/resources/views/components/appointment-fallback.blade.php
+++ b/resources/views/components/appointment-fallback.blade.php
@@ -54,7 +54,9 @@
 
             <div class="flex flex-wrap gap-3">
                 <button class="brand-btn" type="submit">Versturen</button>
-                <a class="brand-btn-outline" href="tel:0544-373326">Of bel: 0544-373326</a>
+                @if (config('contact.phone'))
+                    <a class="brand-btn-outline" href="tel:{{ config('contact.phone_link') }}">Of bel: {{ config('contact.phone') }}</a>
+                @endif
             </div>
         </form>
     </div>

--- a/resources/views/pages/behandelingen.blade.php
+++ b/resources/views/pages/behandelingen.blade.php
@@ -10,12 +10,11 @@
         <div class="mx-auto w-full max-w-6xl">
             <div class="grid gap-6 md:grid-cols-2">
                 @forelse($pedicureprocedures as $procedure)
-                    @php $procedure = (object) $procedure; @endphp
                     <article class="overflow-hidden rounded-2xl border border-brand-100 bg-white shadow-sm">
                         <div class="img-zoom">
                             <picture>
-                                <source data-srcset="{{ $procedure->webp_img }}" type="image/webp">
-                                <img data-src="{{ $procedure->img }}" class="lazyload h-64 w-full object-cover" alt="" />
+                                <source data-srcset="{{ $procedure->webp_image }}" type="image/webp">
+                                <img data-src="{{ $procedure->image }}" class="lazyload h-64 w-full object-cover" alt="" />
                             </picture>
                         </div>
                         <div class="space-y-4 p-6">

--- a/resources/views/pages/spa-arrangementen.blade.php
+++ b/resources/views/pages/spa-arrangementen.blade.php
@@ -10,12 +10,11 @@
         <div class="mx-auto w-full max-w-6xl">
             <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
                 @forelse($spaprocedures as $procedure)
-                    @php $procedure = (object) $procedure; @endphp
                     <article class="overflow-hidden rounded-2xl border border-brand-100 bg-white shadow-sm">
                         <div class="img-zoom">
                             <picture>
-                                <source data-srcset="{{ $procedure->webp_img }}" type="image/webp">
-                                <img data-src="{{ $procedure->img }}" class="lazyload h-56 w-full object-cover" alt="" />
+                                <source data-srcset="{{ $procedure->webp_image }}" type="image/webp">
+                                <img data-src="{{ $procedure->image }}" class="lazyload h-56 w-full object-cover" alt="" />
                             </picture>
                         </div>
                         <div class="space-y-3 p-6">

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,7 +3,9 @@
 use App\Http\Controllers\HomeController;
 use Illuminate\Support\Facades\Route;
 
+use App\Http\Controllers\Admin\TreatmentController;
 use App\Http\Controllers\AppointmentController;
+use App\Http\Controllers\Auth\LoginController;
 use Spatie\Honeypot\ProtectAgainstSpam;
 
 /*
@@ -30,3 +32,11 @@ Route::get('privacyverklaring', function() {
 Route::post('/mail/appointment', [AppointmentController::class, 'index'])
     ->middleware([ProtectAgainstSpam::class, 'throttle:5,1'])
     ->name('mail.appointment');
+
+Route::get('/admin/login', [LoginController::class, 'showLoginForm'])->middleware('guest')->name('login');
+Route::post('/admin/login', [LoginController::class, 'login'])->middleware('guest');
+Route::post('/admin/logout', [LoginController::class, 'logout'])->middleware('auth')->name('logout');
+
+Route::middleware('auth')->prefix('admin')->name('admin.')->group(function () {
+    Route::resource('treatments', TreatmentController::class)->except(['show']);
+});

--- a/tests/Feature/Admin/TreatmentControllerTest.php
+++ b/tests/Feature/Admin/TreatmentControllerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Treatment;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class TreatmentControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('treatment_images');
+        Storage::fake('treatment_images_webp');
+    }
+
+    private function actingAsAdmin()
+    {
+        $user = User::create([
+            'name'     => 'Edith',
+            'email'    => 'edith@bijedith.nl',
+            'password' => Hash::make('secret123'),
+        ]);
+
+        return $this->actingAs($user);
+    }
+
+    public function testGuestCannotAccessTreatmentIndex()
+    {
+        $response = $this->get('/admin/treatments');
+
+        $response->assertRedirect('/admin/login');
+    }
+
+    public function testAuthenticatedUserCanViewTreatmentIndex()
+    {
+        Treatment::create($this->treatmentPayload());
+
+        $response = $this->actingAsAdmin()->get('/admin/treatments');
+
+        $response->assertOk();
+        $response->assertSeeText('Testbehandeling');
+    }
+
+    public function testAuthenticatedUserCanStoreTreatmentWithImage()
+    {
+        $image = UploadedFile::fake()->image('foto.png');
+
+        $response = $this->actingAsAdmin()->post('/admin/treatments', [
+            'category'    => Treatment::CATEGORY_SPA,
+            'name'        => 'Nieuwe spa',
+            'description' => 'Een fijne behandeling.',
+            'image'       => $image,
+        ]);
+
+        $response->assertRedirect('/admin/treatments');
+        $this->assertDatabaseHas('treatments', [
+            'name'     => 'Nieuwe spa',
+            'category' => Treatment::CATEGORY_SPA,
+        ]);
+
+        $treatment = Treatment::where('name', 'Nieuwe spa')->firstOrFail();
+        Storage::disk('treatment_images')->assertExists(basename($treatment->image));
+    }
+
+    public function testAuthenticatedUserCanUpdateTreatmentWithoutReplacingImage()
+    {
+        $treatment = Treatment::create($this->treatmentPayload());
+
+        $response = $this->actingAsAdmin()->put("/admin/treatments/{$treatment->id}", [
+            'category'    => $treatment->category,
+            'name'        => 'Aangepaste naam',
+            'description' => $treatment->description,
+        ]);
+
+        $response->assertRedirect('/admin/treatments');
+        $this->assertDatabaseHas('treatments', [
+            'id'    => $treatment->id,
+            'name'  => 'Aangepaste naam',
+            'image' => $treatment->image,
+        ]);
+    }
+
+    public function testAuthenticatedUserCanDeleteTreatment()
+    {
+        $treatment = Treatment::create($this->treatmentPayload());
+
+        $response = $this->actingAsAdmin()->delete("/admin/treatments/{$treatment->id}");
+
+        $response->assertRedirect('/admin/treatments');
+        $this->assertDatabaseMissing('treatments', ['id' => $treatment->id]);
+    }
+
+    public function testStoreValidatesRequiredFields()
+    {
+        $response = $this->actingAsAdmin()->post('/admin/treatments', []);
+
+        $response->assertSessionHasErrors(['category', 'name', 'description', 'image']);
+    }
+
+    private function treatmentPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'category'    => Treatment::CATEGORY_BEHANDELING,
+            'name'        => 'Testbehandeling',
+            'description' => 'Een test beschrijving.',
+            'image'       => '/assets/pictures/test.png',
+            'webp_image'  => '/assets/pictures/webp/test.webp',
+        ], $overrides);
+    }
+}

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class LoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testGuestCanViewLoginForm()
+    {
+        $response = $this->get('/admin/login');
+
+        $response->assertOk();
+    }
+
+    public function testValidCredentialsLogInAndRedirectToTreatments()
+    {
+        $user = $this->createUser();
+
+        $response = $this->post('/admin/login', [
+            'email'    => $user->email,
+            'password' => 'secret123',
+        ]);
+
+        $response->assertRedirect('/admin/treatments');
+        $this->assertAuthenticatedAs($user);
+    }
+
+    public function testInvalidCredentialsFailValidation()
+    {
+        $user = $this->createUser();
+
+        $response = $this->post('/admin/login', [
+            'email'    => $user->email,
+            'password' => 'wrong-password',
+        ]);
+
+        $response->assertSessionHasErrors('email');
+        $this->assertGuest();
+    }
+
+    public function testGuestIsRedirectedToLoginWhenVisitingAdminArea()
+    {
+        $response = $this->get('/admin/treatments');
+
+        $response->assertRedirect('/admin/login');
+    }
+
+    public function testAuthenticatedUserCanLogOut()
+    {
+        $user = $this->createUser();
+
+        $response = $this->actingAs($user)->post('/admin/logout');
+
+        $response->assertRedirect('/admin/login');
+        $this->assertGuest();
+    }
+
+    private function createUser(): User
+    {
+        return User::create([
+            'name'     => 'Edith',
+            'email'    => 'edith@bijedith.nl',
+            'password' => Hash::make('secret123'),
+        ]);
+    }
+}

--- a/tests/Feature/TreatmentContentTest.php
+++ b/tests/Feature/TreatmentContentTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Treatment;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TreatmentContentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testBehandelingenPageOnlyShowsBehandelingTreatments()
+    {
+        Treatment::create($this->treatmentPayload(['category' => Treatment::CATEGORY_BEHANDELING, 'name' => 'Pedicurebehandeling']));
+        Treatment::create($this->treatmentPayload(['category' => Treatment::CATEGORY_SPA, 'name' => 'Sparkling-arrangement']));
+
+        $response = $this->get('/behandelingen');
+
+        $response->assertOk();
+        $response->assertSeeText('Pedicurebehandeling');
+        $response->assertDontSeeText('Sparkling-arrangement');
+    }
+
+    public function testSpaArrangementenPageOnlyShowsSpaTreatments()
+    {
+        Treatment::create($this->treatmentPayload(['category' => Treatment::CATEGORY_BEHANDELING, 'name' => 'Pedicurebehandeling']));
+        Treatment::create($this->treatmentPayload(['category' => Treatment::CATEGORY_SPA, 'name' => 'Sparkling-arrangement']));
+
+        $response = $this->get('/spa-arrangementen');
+
+        $response->assertOk();
+        $response->assertSeeText('Sparkling-arrangement');
+        $response->assertDontSeeText('Pedicurebehandeling');
+    }
+
+    private function treatmentPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'category'    => Treatment::CATEGORY_BEHANDELING,
+            'name'        => 'Testbehandeling',
+            'description' => 'Een test beschrijving.',
+            'image'       => '/assets/pictures/test.png',
+            'webp_image'  => '/assets/pictures/webp/test.webp',
+        ], $overrides);
+    }
+}


### PR DESCRIPTION
## TLDR
Add a minimal admin area to manage treatments and spa packages. Changed 23 file(s): +793/-64 lines.

## Plan
**Problem.** Edith (the salon owner, non-technical) cannot change a single word of her own treatments or spa packages today. HomeController::behandelingen() and HomeController::spaArrangementen() (app/Http/Controllers/HomeController.php) return hardcoded PHP collections with raw HTML descriptions baked directly into the controller. Adding a treatment, tweaking wording, or swapping a photo requires a developer to edit PHP, commit, and deploy — for a one-person local business that's a disproportionate amount of friction for routine content upkeep.

**Outcome.** Edith can add, edit, or remove a treatment/spa package herself from a small admin screen, with no developer or deploy in the loop.

**Sketch.** The app already ships unused auth scaffolding (app/User.php plus the users/password_resets migrations) that nothing routes to — reuse it to gate a minimal admin area. Move the two hardcoded collections into a `treatments` table + Eloquent model, replace the array literals in HomeController with a DB query, and build a bare CRUD form (name, description, category, image). Main risk: scope creep into a general page builder — keep it strictly to the two collections that already exist as structured data, and make image upload slot into the existing webp.js/mix asset pipeline instead of bypassing it.

---
*Generated by Claude Runner*