### PR TITLE
Send customers a proper confirmation email instead of the internal staff notification

### DIFF
--- a/app/Http/Controllers/AppointmentController.php
+++ b/app/Http/Controllers/AppointmentController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Appointment;
 use App\Http\Requests\AppointmentRequest;
+use App\Mail\AppointmentConfirmationMail;
 use App\Mail\AppointmentMail;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -31,8 +32,16 @@ class AppointmentController extends Controller
             $appointment->message
         );
 
+        $confirmationMail = new AppointmentConfirmationMail(
+            $appointment->name,
+            $appointment->email,
+            $appointment->procedure,
+            $appointment->phone,
+            $appointment->message
+        );
+
         try {
-            Mail::to($appointment->email)->send($mail);
+            Mail::to($appointment->email)->send($confirmationMail);
             Mail::to('info@bijedith.nl')->send($mail);
         } catch (Throwable $exception) {
             Log::error('Failed to send appointment mail.', [

--- a/app/Mail/AppointmentConfirmationMail.php
+++ b/app/Mail/AppointmentConfirmationMail.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class AppointmentConfirmationMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $name;
+    public $email;
+    public $procedure;
+    public $phone;
+    public $message;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct($name, $email, $procedure, $phone, $message = null)
+    {
+        $this->name = $name;
+        $this->email = $email;
+        $this->procedure = $procedure;
+        $this->phone = $phone;
+        $this->message = $message;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this
+            ->from('info@bijedith.nl')
+            ->subject('Bevestiging van uw aanvraag')
+            ->markdown('mails.appointment-confirmation');
+    }
+}

--- a/resources/views/mails/appointment-confirmation.blade.php
+++ b/resources/views/mails/appointment-confirmation.blade.php
@@ -1,0 +1,16 @@
+@component('mail::message')
+# Bedankt voor uw aanvraag
+
+Bedankt voor uw aanvraag bij BijEdith, wij nemen zo spoedig mogelijk contact met u op.
+
+@component('mail::panel')
+<strong>Naam:</strong> {{ $name }}<br/>
+<strong>Email:</strong> {{ $email }}<br/>
+<strong>Behandeling:</strong> {{ $procedure }}<br/>
+<strong>Telefoonnummer:</strong> {{ $phone }}<br/>
+<strong>Opmerking:</strong> {{ $message ?? 'Geen opmerking achtergelaten.' }}
+@endcomponent
+
+Vriendelijke groet,<br>
+BijEdith
+@endcomponent

--- a/tests/Feature/AppointmentControllerTest.php
+++ b/tests/Feature/AppointmentControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Appointment;
+use App\Mail\AppointmentConfirmationMail;
 use App\Mail\AppointmentMail;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
@@ -34,13 +35,12 @@ class AppointmentControllerTest extends TestCase
         $response->assertRedirect('/');
         $response->assertSessionHas('success');
 
-        Mail::assertSent(AppointmentMail::class, function ($mail) {
+        Mail::assertSent(AppointmentConfirmationMail::class, function ($mail) {
             return $mail->hasTo('jane@example.com');
         });
         Mail::assertSent(AppointmentMail::class, function ($mail) {
             return $mail->hasTo(self::INFO_EMAIL);
         });
-        Mail::assertSent(AppointmentMail::class, 2);
     }
 
     public function testValidPayloadPersistsAppointment()
@@ -145,7 +145,8 @@ class AppointmentControllerTest extends TestCase
         $response = $this->post('/mail/appointment', $this->validPayload());
 
         $response->assertStatus(429);
-        Mail::assertSent(AppointmentMail::class, 10);
+        Mail::assertSent(AppointmentConfirmationMail::class, 5);
+        Mail::assertSent(AppointmentMail::class, 5);
     }
 
     public function testMissingMessageIsOptionalAndSucceeds()
@@ -159,6 +160,11 @@ class AppointmentControllerTest extends TestCase
 
         $response->assertRedirect('/');
         $response->assertSessionHas('success');
-        Mail::assertSent(AppointmentMail::class, 2);
+        Mail::assertSent(AppointmentConfirmationMail::class, function ($mail) {
+            return $mail->hasTo('jane@example.com');
+        });
+        Mail::assertSent(AppointmentMail::class, function ($mail) {
+            return $mail->hasTo(self::INFO_EMAIL);
+        });
     }
 }


### PR DESCRIPTION
## TLDR
Send customers a dedicated confirmation email instead of the staff notification. Changed 4 file(s): +82/-5 lines.

## Plan
1) Add a new Mailable app/Mail/AppointmentConfirmationMail.php mirroring app/Mail/AppointmentMail.php's constructor ($name, $email, $procedure, $phone, $message) but with its own subject (e.g. 'Bevestiging van uw aanvraag') and markdown view. 2) Add resources/views/mails/appointment-confirmation.blade.php with customer-appropriate copy (e.g. 'Bedankt voor uw aanvraag bij BijEdith, wij nemen zo spoedig mogelijk contact met u op' plus a summary panel of what was submitted), leaving resources/views/mails/appointment.blade.php unchanged for staff. 3) In app/Http/Controllers/AppointmentController.php, keep `Mail::to('info@bijedith.nl')->send($mail)` using AppointmentMail, and change the customer send to `Mail::to($request->input('email'))->send(new AppointmentConfirmationMail(...))` with the same field values. 4) Update tests/Feature/AppointmentControllerTest.php: import AppointmentConfirmationMail, change testValidPayloadSendsAppointmentMailsAndRedirectsWithSuccess and testMissingMessageIsOptionalAndSucceeds to assert `Mail::assertSent(AppointmentConfirmationMail::class, fn ($mail) => $mail->hasTo('jane@example.com'))` and `Mail::assertSent(AppointmentMail::class, fn ($mail) => $mail->hasTo('info@bijedith.nl'))` (one of each) instead of `Mail::assertSent(AppointmentMail::class, 2)`; update testSixthSubmissionWithinOneMinuteIsRateLimited's counts to assert 5 of each class instead of 10 of AppointmentMail.

---
*Generated by Claude Runner*