### PR TITLE
Guard testimonial approve/reject links against email-scanner prefetching

### DIFF
--- a/app/Http/Controllers/TestimonialController.php
+++ b/app/Http/Controllers/TestimonialController.php
@@ -8,6 +8,7 @@ use App\Testimonial;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\URL;
 
 class TestimonialController extends Controller
 {
@@ -27,6 +28,15 @@ class TestimonialController extends Controller
         Mail::to('info@bijedith.nl')->send(new TestimonialApprovalMail($testimonial));
 
         return redirect()->route('testimonials.create')->with('success', 'Bedankt voor uw review! Deze wordt na goedkeuring op de website geplaatst.');
+    }
+
+    public function review(Testimonial $testimonial): Renderable
+    {
+        return view('pages.testimonial-review', [
+            'testimonial' => $testimonial,
+            'approveUrl'  => URL::signedRoute('testimonials.approve', ['testimonial' => $testimonial->id]),
+            'rejectUrl'   => URL::signedRoute('testimonials.reject', ['testimonial' => $testimonial->id]),
+        ]);
     }
 
     public function approve(Testimonial $testimonial): RedirectResponse

--- a/app/Mail/TestimonialApprovalMail.php
+++ b/app/Mail/TestimonialApprovalMail.php
@@ -14,8 +14,7 @@ class TestimonialApprovalMail extends Mailable
     use Queueable, SerializesModels;
 
     public $testimonial;
-    public $approveUrl;
-    public $rejectUrl;
+    public $reviewUrl;
 
     /**
      * Create a new message instance.
@@ -25,8 +24,7 @@ class TestimonialApprovalMail extends Mailable
     public function __construct(Testimonial $testimonial)
     {
         $this->testimonial = $testimonial;
-        $this->approveUrl = URL::signedRoute('testimonials.approve', ['testimonial' => $testimonial->id]);
-        $this->rejectUrl = URL::signedRoute('testimonials.reject', ['testimonial' => $testimonial->id]);
+        $this->reviewUrl = URL::signedRoute('testimonials.review', ['testimonial' => $testimonial->id]);
     }
 
     /**

--- a/resources/views/mails/testimonial-approval.blade.php
+++ b/resources/views/mails/testimonial-approval.blade.php
@@ -9,14 +9,10 @@ Er is een nieuwe review binnengekomen voor BijEdith.
 <strong>Review:</strong> {{ $testimonial->quote }}
 @endcomponent
 
-Keur de review goed om deze op de website te tonen, of wijs de review af.
+Bekijk de review om deze goed te keuren of af te wijzen.
 
-@component('mail::button', ['url' => $approveUrl])
-Goedkeuren
-@endcomponent
-
-@component('mail::button', ['url' => $rejectUrl, 'color' => 'error'])
-Afwijzen
+@component('mail::button', ['url' => $reviewUrl])
+Review bekijken
 @endcomponent
 
 Vriendelijke groet,<br>

--- a/resources/views/pages/testimonial-review.blade.php
+++ b/resources/views/pages/testimonial-review.blade.php
@@ -1,0 +1,30 @@
+@extends('master')
+@section('content')
+    @include('components.page-header', [
+        'kicker' => '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"/></svg> Review',
+        'title' => 'Review beoordelen',
+        'subtitle' => 'Keur deze review goed om hem op de website te tonen, of wijs hem af.',
+    ])
+
+    <section class="px-4 pb-16 sm:px-6 lg:px-8">
+        <div class="mx-auto w-full max-w-3xl rounded-3xl border border-brand-100 bg-white p-6 shadow-sm lg:p-10">
+            <p class="text-base font-medium text-gray-900">{{ $testimonial->author }}</p>
+            @if ($testimonial->role)
+                <p class="text-sm text-gray-500">{{ $testimonial->role }}</p>
+            @endif
+            <p class="mt-4 text-base text-gray-900">{{ $testimonial->quote }}</p>
+
+            <div class="mt-6 flex flex-wrap gap-3">
+                <form method="POST" action="{{ $approveUrl }}">
+                    @csrf
+                    <button class="brand-btn" type="submit">Goedkeuren</button>
+                </form>
+
+                <form method="POST" action="{{ $rejectUrl }}">
+                    @csrf
+                    <button class="brand-btn" type="submit">Afwijzen</button>
+                </form>
+            </div>
+        </div>
+    </section>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,10 +38,13 @@ Route::get('/ervaring-delen', [TestimonialController::class, 'create'])->name('t
 Route::post('/mail/testimonial', [TestimonialController::class, 'store'])
     ->middleware([ProtectAgainstSpam::class, 'throttle:5,1'])
     ->name('mail.testimonial');
-Route::get('/testimonials/{testimonial}/approve', [TestimonialController::class, 'approve'])
+Route::get('/testimonials/{testimonial}/review', [TestimonialController::class, 'review'])
+    ->middleware('signed')
+    ->name('testimonials.review');
+Route::post('/testimonials/{testimonial}/approve', [TestimonialController::class, 'approve'])
     ->middleware('signed')
     ->name('testimonials.approve');
-Route::get('/testimonials/{testimonial}/reject', [TestimonialController::class, 'reject'])
+Route::post('/testimonials/{testimonial}/reject', [TestimonialController::class, 'reject'])
     ->middleware('signed')
     ->name('testimonials.reject');
 Route::get('/login', [LoginController::class, 'create'])->middleware('guest')->name('login');

--- a/tests/Feature/TestimonialControllerTest.php
+++ b/tests/Feature/TestimonialControllerTest.php
@@ -115,7 +115,7 @@ class TestimonialControllerTest extends TestCase
         $testimonial = Testimonial::create($this->validPayload());
         $url = URL::signedRoute('testimonials.approve', ['testimonial' => $testimonial->id]);
 
-        $response = $this->get($url);
+        $response = $this->post($url);
 
         $response->assertRedirect(route('home'));
         $this->assertNotNull($testimonial->fresh()->approved_at);
@@ -125,7 +125,7 @@ class TestimonialControllerTest extends TestCase
     {
         $testimonial = Testimonial::create($this->validPayload());
 
-        $response = $this->get("/testimonials/{$testimonial->id}/approve");
+        $response = $this->post("/testimonials/{$testimonial->id}/approve");
 
         $response->assertStatus(403);
         $this->assertNull($testimonial->fresh()->approved_at);
@@ -136,7 +136,7 @@ class TestimonialControllerTest extends TestCase
         $testimonial = Testimonial::create($this->validPayload());
         $url = URL::signedRoute('testimonials.reject', ['testimonial' => $testimonial->id]);
 
-        $response = $this->get($url);
+        $response = $this->post($url);
 
         $response->assertRedirect(route('home'));
         $this->assertDatabaseMissing('testimonials', ['id' => $testimonial->id]);
@@ -146,9 +146,21 @@ class TestimonialControllerTest extends TestCase
     {
         $testimonial = Testimonial::create($this->validPayload());
 
-        $response = $this->get("/testimonials/{$testimonial->id}/reject");
+        $response = $this->post("/testimonials/{$testimonial->id}/reject");
 
         $response->assertStatus(403);
+        $this->assertDatabaseHas('testimonials', ['id' => $testimonial->id]);
+    }
+
+    public function testValidSignedReviewUrlDoesNotMutateTheTestimonial()
+    {
+        $testimonial = Testimonial::create($this->validPayload());
+        $url = URL::signedRoute('testimonials.review', ['testimonial' => $testimonial->id]);
+
+        $response = $this->get($url);
+
+        $response->assertStatus(200);
+        $this->assertNull($testimonial->fresh()->approved_at);
         $this->assertDatabaseHas('testimonials', ['id' => $testimonial->id]);
     }
 }


### PR DESCRIPTION
## TLDR
Guard testimonial approve/reject against email-scanner prefetching. Changed 6 file(s): +66/-17 lines.

## Plan
1) In routes/web.php replace the two GET routes with a single signed GET route (e.g. `/testimonials/{testimonial}/review`) that renders a confirmation view showing the quote plus two POST buttons/forms (approve/reject), and two signed POST routes `testimonials.approve`/`testimonials.reject` that perform the mutation. 2) In app/Http/Controllers/TestimonialController.php split `approve`/`reject` into a new `review(Testimonial $testimonial)` (GET, returns a new view e.g. resources/views/pages/testimonial-review.blade.php, no mutation) and keep `approve`/`reject` as the POST handlers with the same logic they have today. 3) Update app/Mail/TestimonialApprovalMail.php to build `approveUrl`/`rejectUrl` (or a single reviewUrl) via `URL::signedRoute('testimonials.review', ...)` instead of pointing straight at the mutating routes, and update resources/views/mails/testimonial-approval.blade.php accordingly. 4) Update tests/Feature/TestimonialControllerTest.php: change testValidSignedUrlApprovesTheTestimonial / testValidSignedUrlRejectsAndDeletesTheTestimonial / testUnsignedApprovalUrlIsForbidden / testUnsignedRejectionUrlIsForbidden to `$this->post($url)` against the new POST routes, and add a new test asserting a plain signed GET to the review route does NOT mutate the testimonial (approved_at still null / row still exists) — this is the regression test that proves the prefetch bug is fixed.

---
*Generated by Claude Runner*