### PR TITLE
Drive the appointment-fallback treatment picker from real Treatment records

### DIFF
--- a/app/Http/Requests/AppointmentRequest.php
+++ b/app/Http/Requests/AppointmentRequest.php
@@ -2,10 +2,20 @@
 
 namespace App\Http\Requests;
 
+use App\Treatment;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class AppointmentRequest extends FormRequest
 {
+    /**
+     * Fallback options used when no Treatment records exist yet, so the
+     * form never hard-fails validation for a customer.
+     *
+     * @var array
+     */
+    private const FALLBACK_PROCEDURES = ['pedicure', 'spabehandeling'];
+
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -23,10 +33,12 @@ class AppointmentRequest extends FormRequest
      */
     public function rules()
     {
+        $procedures = Treatment::pluck('name')->all() ?: self::FALLBACK_PROCEDURES;
+
         return [
             'name'          => 'required|min:2|max:50',
             'email'         => 'required|email|min:5|max:100',
-            'procedure'     => 'required|in:pedicure,spabehandeling',
+            'procedure'     => ['required', Rule::in($procedures)],
             'phone'         => 'required|min:5|max:25',
             'message'       => 'nullable|max:350',
             'opt_in'        => 'required|accepted',

--- a/resources/views/components/appointment-fallback.blade.php
+++ b/resources/views/components/appointment-fallback.blade.php
@@ -31,8 +31,13 @@
                     <span class="text-base font-medium text-gray-900">Behandeling</span>
                     <select class="mt-1 w-full rounded-xl border border-brand-100 px-4 py-3 text-base text-gray-900" name="procedure" required>
                         <option value="" disabled @if (! old('procedure')) selected @endif>Selecteer behandeling</option>
-                        <option value="pedicure" @if (old('procedure') === 'pedicure') selected @endif>Pedicure</option>
-                        <option value="spabehandeling" @if (old('procedure') === 'spabehandeling') selected @endif>Spabehandeling</option>
+                        @foreach (\App\Treatment::orderBy('type')->orderBy('name')->get()->groupBy('type') as $type => $treatments)
+                            <optgroup label="{{ ucfirst($type) }}">
+                                @foreach ($treatments as $treatment)
+                                    <option value="{{ $treatment->name }}" @if (old('procedure') === $treatment->name) selected @endif>{{ $treatment->name }}</option>
+                                @endforeach
+                            </optgroup>
+                        @endforeach
                     </select>
                 </label>
 

--- a/tests/Feature/AppointmentControllerTest.php
+++ b/tests/Feature/AppointmentControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Appointment;
 use App\Mail\AppointmentConfirmationMail;
 use App\Mail\AppointmentMail;
+use App\Treatment;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
@@ -128,6 +129,40 @@ class AppointmentControllerTest extends TestCase
         Mail::fake();
 
         $response = $this->post('/mail/appointment', $this->validPayload(['procedure' => 'massage']));
+
+        $response->assertSessionHasErrors(['procedure']);
+        Mail::assertNothingSent();
+    }
+
+    public function testProcedureAcceptsAnExistingTreatmentName()
+    {
+        Mail::fake();
+
+        $treatment = Treatment::create([
+            'type'        => 'spa',
+            'name'        => 'Sparkling-arrangement',
+            'description' => 'Beschrijving',
+            'image'       => '/assets/pictures/spa.png',
+        ]);
+
+        $response = $this->post('/mail/appointment', $this->validPayload(['procedure' => $treatment->name]));
+
+        $response->assertRedirect('/');
+        $response->assertSessionHas('success');
+    }
+
+    public function testProcedureRejectsANameThatIsNotAKnownTreatmentWhenTreatmentsExist()
+    {
+        Mail::fake();
+
+        Treatment::create([
+            'type'        => 'spa',
+            'name'        => 'Sparkling-arrangement',
+            'description' => 'Beschrijving',
+            'image'       => '/assets/pictures/spa.png',
+        ]);
+
+        $response = $this->post('/mail/appointment', $this->validPayload(['procedure' => 'pedicure']));
 
         $response->assertSessionHasErrors(['procedure']);
         Mail::assertNothingSent();

--- a/tests/Feature/AppointmentFallbackTest.php
+++ b/tests/Feature/AppointmentFallbackTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Treatment;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
@@ -38,6 +39,29 @@ class AppointmentFallbackTest extends TestCase
 
         $response->assertSee('onerror="window.salonizedWidgetFailed()"', false);
         $response->assertSee('[data-booking-fallback][hidden] { display: block !important; }', false);
+    }
+
+    public function testFallbackFormListsTreatmentsFromTheDatabaseGroupedByType()
+    {
+        $pedicure = Treatment::create([
+            'type'        => 'pedicure',
+            'name'        => 'Gespecialiseerde pedicurebehandeling',
+            'description' => 'Beschrijving',
+            'image'       => '/assets/pictures/pedicure.png',
+        ]);
+        $spa = Treatment::create([
+            'type'        => 'spa',
+            'name'        => 'Sparkling-arrangement',
+            'description' => 'Beschrijving',
+            'image'       => '/assets/pictures/spa.png',
+        ]);
+
+        $response = $this->get('/');
+
+        $response->assertSee('<option value="' . $pedicure->name . '"', false);
+        $response->assertSee('<option value="' . $spa->name . '"', false);
+        $response->assertDontSee('<option value="pedicure"', false);
+        $response->assertDontSee('<option value="spabehandeling"', false);
     }
 
     public function testFallbackFormIsRevealedWhenSubmissionFailsValidation()


### PR DESCRIPTION
## TLDR
Drive appointment-fallback treatment picker from Treatment records. Changed 4 file(s): +79/-3 lines.

## Plan
**Problem.** The fallback form's 'Behandeling' select is hardcoded to two generic options, 'pedicure' and 'spabehandeling' (resources/views/components/appointment-fallback.blade.php:34-35), matching a static enum in AppointmentRequest::rules() (app/Http/Requests/AppointmentRequest.php:29). Meanwhile Edith now manages five specific named treatments (e.g. 'Sparkling-arrangement', 'Gespecialiseerde pedicurebehandeling') through the admin CRUD added for the treatments page (app/Http/Controllers/Admin/TreatmentController.php). A customer using the fallback form can only say 'spabehandeling' in general — staff then have to chase them by phone/email to learn which actual treatment they wanted, and the two vocabularies have already drifted (Treatment.type uses 'spa', the form/validation uses 'spabehandeling').

**Outcome.** Customers pick the exact treatment they want from the same list Edith curates in /admin/treatments, and staff receive a specific request instead of a vague category.

**Sketch.** Replace the two hardcoded <option> values in appointment-fallback.blade.php with a loop over Treatment::orderBy('type')->orderBy('name')->get(), grouped by type; replace AppointmentRequest's static in:pedicure,spabehandeling rule with a dynamic in: list built from Treatment::pluck('name'). Appointment.procedure stays a plain string column — no migration, no FK, no auth touched. Main risk: validation must not hard-fail if the Treatment table is ever empty (keep a safe fallback or a clear validation message) — small, contained change in 2-3 files.

---
*Generated by Claude Runner*