### PR TITLE
Add test coverage for AppointmentRequest's fallback-procedure list

### DIFF
--- a/tests/Feature/AppointmentControllerTest.php
+++ b/tests/Feature/AppointmentControllerTest.php
@@ -168,6 +168,32 @@ class AppointmentControllerTest extends TestCase
         Mail::assertNothingSent();
     }
 
+    public function testProcedureAcceptsAFallbackProcedureWhenNoTreatmentsExist()
+    {
+        Mail::fake();
+
+        Treatment::query()->delete();
+        $this->assertSame(0, Treatment::count());
+
+        $response = $this->post('/mail/appointment', $this->validPayload(['procedure' => 'pedicure']));
+
+        $response->assertRedirect('/');
+        $response->assertSessionHas('success');
+    }
+
+    public function testProcedureRejectsANameThatIsNotAFallbackProcedureWhenNoTreatmentsExist()
+    {
+        Mail::fake();
+
+        Treatment::query()->delete();
+        $this->assertSame(0, Treatment::count());
+
+        $response = $this->post('/mail/appointment', $this->validPayload(['procedure' => 'massage']));
+
+        $response->assertSessionHasErrors(['procedure']);
+        Mail::assertNothingSent();
+    }
+
     public function testSixthSubmissionWithinOneMinuteIsRateLimited()
     {
         Mail::fake();


### PR DESCRIPTION
## TLDR
Add test coverage for AppointmentRequest fallback-procedure list. Changed 1 file(s): +26/-0 lines.

## Plan
In tests/Feature/AppointmentControllerTest.php, add a test that ensures the treatments table is empty (no seeding, or explicitly Treatment::query()->delete() if a base seeder runs), then POSTs an appointment request using one of the FALLBACK_PROCEDURES values (e.g. 'pedicure') from app/Http/Requests/AppointmentRequest.php and asserts it validates successfully (redirect/success response, not a validation error). Add a second case asserting an unrelated procedure name is still rejected in the fallback state. Run php artisan test to confirm the new tests pass and don't break existing ones.

---
*Generated by Claude Runner*