### PR TITLE
Add rate limiting to the login route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -48,7 +48,7 @@ Route::post('/testimonials/{testimonial}/reject', [TestimonialController::class,
     ->middleware('signed')
     ->name('testimonials.reject');
 Route::get('/login', [LoginController::class, 'create'])->middleware('guest')->name('login');
-Route::post('/login', [LoginController::class, 'store'])->middleware('guest');
+Route::post('/login', [LoginController::class, 'store'])->middleware(['guest', 'throttle:5,1']);
 Route::post('/logout', [LoginController::class, 'destroy'])->middleware('auth')->name('logout');
 
 Route::prefix('admin')->name('admin.')->middleware('auth')->group(function () {

--- a/tests/Feature/Auth/LoginControllerTest.php
+++ b/tests/Feature/Auth/LoginControllerTest.php
@@ -45,6 +45,30 @@ class LoginControllerTest extends TestCase
         $this->assertGuest();
     }
 
+    public function testSixthSubmissionWithinOneMinuteIsRateLimited()
+    {
+        User::create([
+            'name'     => 'Edith',
+            'email'    => 'edith@bijedith.nl',
+            'password' => Hash::make('correct-password'),
+        ]);
+
+        for ($i = 0; $i < 5; $i++) {
+            $response = $this->post('/login', [
+                'email'    => 'edith@bijedith.nl',
+                'password' => 'wrong-password',
+            ]);
+            $response->assertSessionHasErrors(['email']);
+        }
+
+        $response = $this->post('/login', [
+            'email'    => 'edith@bijedith.nl',
+            'password' => 'wrong-password',
+        ]);
+
+        $response->assertStatus(429);
+    }
+
     public function testAuthenticatedUserCanLogOut()
     {
         $user = User::create([


### PR DESCRIPTION
## TLDR
Add rate limiting to the login route. Changed 2 file(s): +25/-1 lines.

## Plan
In routes/web.php, add ->middleware('throttle:5,1') to the POST /login route (line ~48), matching the pattern already used for the contact route (line 34) and testimonial route (lines 39-40). Add a new test in tests/Feature/Auth/ (create if it doesn't exist, following the LoginControllerTest naming convention) that mirrors the existing throttle assertions in tests/Feature/AppointmentControllerTest.php:170-183 and tests/Feature/TestimonialControllerTest.php:96-107 — submit 6 login attempts within a minute and assert the 6th returns 429. Run php artisan test to confirm.

---
*Generated by Claude Runner*