### PR TITLE
Remove approved_at from Testimonial's mass-assignable fields

### DIFF
--- a/app/Testimonial.php
+++ b/app/Testimonial.php
@@ -13,7 +13,7 @@ class Testimonial extends Model
      * @var array
      */
     protected $fillable = [
-        'author', 'role', 'quote', 'approved_at',
+        'author', 'role', 'quote',
     ];
 
     /**

--- a/tests/Feature/TestimonialControllerTest.php
+++ b/tests/Feature/TestimonialControllerTest.php
@@ -82,6 +82,19 @@ class TestimonialControllerTest extends TestCase
         Mail::assertNothingSent();
     }
 
+    public function testApprovedAtCannotBeSetViaSubmission()
+    {
+        Mail::fake();
+
+        $response = $this->post('/mail/testimonial', $this->validPayload(['approved_at' => now()]));
+
+        $response->assertRedirect(route('testimonials.create'));
+        $this->assertDatabaseHas('testimonials', [
+            'author'      => 'Jane Doe',
+            'approved_at' => null,
+        ]);
+    }
+
     public function testMissingRoleIsOptionalAndSucceeds()
     {
         Mail::fake();


### PR DESCRIPTION
## TLDR
Remove approved_at from Testimonial mass-assignable fields. Changed 2 file(s): +14/-1 lines.

## Plan
In app/Testimonial.php, remove 'approved_at' from the $fillable array (line ~14-16). Verify app/Http/Controllers/TestimonialController.php approve()/reject() methods (lines 42-53) still work since they use explicit ->update([...]) calls, not mass assignment from request input. Add a regression test in tests/Feature/TestimonialControllerTest.php that POSTs to the public testimonial submission route with a crafted approved_at field in the body and asserts the created Testimonial record has approved_at still null (i.e. it cannot self-approve). Run the existing TestimonialControllerTest suite to confirm approve/reject still pass.

---
*Generated by Claude Runner*