### PR TITLE
Add reply-to address to staff booking-notification email

### DIFF
--- a/app/Mail/AppointmentMail.php
+++ b/app/Mail/AppointmentMail.php
@@ -40,6 +40,7 @@ class AppointmentMail extends Mailable
     {
         return $this
             ->from('info@bijedith.nl')
+            ->replyTo($this->email, $this->name)
             ->subject('Nieuwe aanvraag voor behandeling')
             ->markdown('mails.appointment');
     }

--- a/tests/Feature/AppointmentControllerTest.php
+++ b/tests/Feature/AppointmentControllerTest.php
@@ -40,7 +40,7 @@ class AppointmentControllerTest extends TestCase
             return $mail->hasTo('jane@example.com');
         });
         Mail::assertSent(AppointmentMail::class, function ($mail) {
-            return $mail->hasTo(self::INFO_EMAIL);
+            return $mail->hasTo(self::INFO_EMAIL) && $mail->hasReplyTo('jane@example.com');
         });
     }
 


### PR DESCRIPTION
## TLDR
Add reply-to address to staff booking-notification email. Changed 2 file(s): +2/-1 lines.

## Plan
In app/Mail/AppointmentMail.php, add ->replyTo($this->email, $this->name) inside the build() method (currently only sets ->from('info@bijedith.nl') around lines 41-44; the constructor already stores $this->email/$this->name from the Appointment model, lines 25-32). Add a test assertion in tests/Feature/AppointmentControllerTest.php alongside the existing Mail::assertSent(AppointmentMail::class, fn($mail) => $mail->hasTo(...)) block (around lines 39-45), asserting $mail->hasReplyTo($appointment->email).

---
*Generated by Claude Runner*