### PR TITLE
Expire testimonial approve/reject signed links

### DIFF
--- a/app/Http/Controllers/TestimonialController.php
+++ b/app/Http/Controllers/TestimonialController.php
@@ -34,8 +34,8 @@ class TestimonialController extends Controller
     {
         return view('pages.testimonial-review', [
             'testimonial' => $testimonial,
-            'approveUrl'  => URL::signedRoute('testimonials.approve', ['testimonial' => $testimonial->id]),
-            'rejectUrl'   => URL::signedRoute('testimonials.reject', ['testimonial' => $testimonial->id]),
+            'approveUrl'  => URL::temporarySignedRoute('testimonials.approve', now()->addDays(7), ['testimonial' => $testimonial->id]),
+            'rejectUrl'   => URL::temporarySignedRoute('testimonials.reject', now()->addDays(7), ['testimonial' => $testimonial->id]),
         ]);
     }
 

--- a/app/Mail/TestimonialApprovalMail.php
+++ b/app/Mail/TestimonialApprovalMail.php
@@ -24,7 +24,7 @@ class TestimonialApprovalMail extends Mailable
     public function __construct(Testimonial $testimonial)
     {
         $this->testimonial = $testimonial;
-        $this->reviewUrl = URL::signedRoute('testimonials.review', ['testimonial' => $testimonial->id]);
+        $this->reviewUrl = URL::temporarySignedRoute('testimonials.review', now()->addDays(7), ['testimonial' => $testimonial->id]);
     }
 
     /**

--- a/tests/Feature/TestimonialControllerTest.php
+++ b/tests/Feature/TestimonialControllerTest.php
@@ -144,6 +144,17 @@ class TestimonialControllerTest extends TestCase
         $this->assertNull($testimonial->fresh()->approved_at);
     }
 
+    public function testExpiredApprovalUrlIsForbidden()
+    {
+        $testimonial = Testimonial::create($this->validPayload());
+        $url = URL::temporarySignedRoute('testimonials.approve', now()->addDays(7), ['testimonial' => $testimonial->id]);
+
+        $response = $this->travel(8)->days()->post($url);
+
+        $response->assertStatus(403);
+        $this->assertNull($testimonial->fresh()->approved_at);
+    }
+
     public function testValidSignedUrlRejectsAndDeletesTheTestimonial()
     {
         $testimonial = Testimonial::create($this->validPayload());
@@ -160,6 +171,17 @@ class TestimonialControllerTest extends TestCase
         $testimonial = Testimonial::create($this->validPayload());
 
         $response = $this->post("/testimonials/{$testimonial->id}/reject");
+
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('testimonials', ['id' => $testimonial->id]);
+    }
+
+    public function testExpiredRejectionUrlIsForbidden()
+    {
+        $testimonial = Testimonial::create($this->validPayload());
+        $url = URL::temporarySignedRoute('testimonials.reject', now()->addDays(7), ['testimonial' => $testimonial->id]);
+
+        $response = $this->travel(8)->days()->post($url);
 
         $response->assertStatus(403);
         $this->assertDatabaseHas('testimonials', ['id' => $testimonial->id]);


### PR DESCRIPTION
## TLDR
Expire testimonial approve/reject/review signed links after 7 days. Changed 3 file(s): +25/-3 lines.

## Plan
In app/Mail/TestimonialApprovalMail.php:27 and app/Http/Controllers/TestimonialController.php:37-38, replace URL::signedRoute(...) with URL::temporarySignedRoute($name, now()->addDays(7), $params) (pick a reasonable TTL, e.g. 7 days). Add a new test testExpiredApprovalUrlIsForbidden in tests/Feature/TestimonialControllerTest.php, following the existing testUnsignedApprovalUrlIsForbidden pattern (lines 137-145) but using $this->travel(8)->days() or Carbon::setTestNow to move past the expiry before hitting the route, asserting assertStatus(403). Mirror for the rejection route (lines 158-166).

---
*Generated by Claude Runner*