### PR TITLE
Enforce unique treatment names to prevent duplicate booking-dropdown entries

### DIFF
--- a/app/Http/Requests/TreatmentRequest.php
+++ b/app/Http/Requests/TreatmentRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class TreatmentRequest extends FormRequest
 {
@@ -27,7 +28,12 @@ class TreatmentRequest extends FormRequest
 
         return [
             'type'        => 'required|in:pedicure,spa',
-            'name'        => 'required|min:2|max:255',
+            'name'        => [
+                'required',
+                'min:2',
+                'max:255',
+                Rule::unique('treatments', 'name')->ignore($this->route('treatment')),
+            ],
             'description' => 'required',
             'image'       => $imageRule . '|image|max:4096',
         ];

--- a/tests/Feature/Admin/TreatmentControllerTest.php
+++ b/tests/Feature/Admin/TreatmentControllerTest.php
@@ -64,6 +64,28 @@ class TreatmentControllerTest extends TestCase
         $this->assertDatabaseMissing('treatments', ['name' => 'Nieuwe behandeling']);
     }
 
+    public function testCreatingTreatmentWithDuplicateNameFailsValidation()
+    {
+        Storage::fake('public');
+
+        Treatment::create([
+            'type'        => 'pedicure',
+            'name'        => 'Bestaande behandeling',
+            'description' => 'Een omschrijving',
+            'image'       => UploadedFile::fake()->image('old.jpg')->store('treatments', 'public'),
+        ]);
+
+        $response = $this->actingAs($this->user())->post('/admin/treatments', [
+            'type'        => 'pedicure',
+            'name'        => 'Bestaande behandeling',
+            'description' => 'Een andere omschrijving',
+            'image'       => UploadedFile::fake()->image('treatment.jpg'),
+        ]);
+
+        $response->assertSessionHasErrors(['name']);
+        $this->assertDatabaseMissing('treatments', ['description' => 'Een andere omschrijving']);
+    }
+
     public function testAuthenticatedUserCanUpdateTreatmentWithoutReplacingImage()
     {
         Storage::fake('public');
@@ -85,6 +107,31 @@ class TreatmentControllerTest extends TestCase
         $this->assertDatabaseHas('treatments', [
             'id'   => $treatment->id,
             'name' => 'Nieuwe naam',
+        ]);
+    }
+
+    public function testAuthenticatedUserCanUpdateTreatmentKeepingItsOwnName()
+    {
+        Storage::fake('public');
+
+        $treatment = Treatment::create([
+            'type'        => 'spa',
+            'name'        => 'Ongewijzigde naam',
+            'description' => 'Oude omschrijving',
+            'image'       => UploadedFile::fake()->image('old.jpg')->store('treatments', 'public'),
+        ]);
+
+        $response = $this->actingAs($this->user())->put("/admin/treatments/{$treatment->id}", [
+            'type'        => 'spa',
+            'name'        => 'Ongewijzigde naam',
+            'description' => 'Nieuwe omschrijving',
+        ]);
+
+        $response->assertRedirect(route('admin.treatments.index'));
+        $this->assertDatabaseHas('treatments', [
+            'id'          => $treatment->id,
+            'name'        => 'Ongewijzigde naam',
+            'description' => 'Nieuwe omschrijving',
         ]);
     }
 


### PR DESCRIPTION
## TLDR
Enforce unique treatment names to prevent duplicate booking-dropdown entries. Changed 2 file(s): +54/-1 lines.

## Plan
In app/Http/Requests/TreatmentRequest.php (rules currently required|min:2|max:255 for name, lines 24-34), add Rule::unique('treatments','name')->ignore($this->route('treatment')) to the name rule so it works for both create and update. Add tests in tests/Feature/Admin/TreatmentControllerTest.php: testCreatingTreatmentWithDuplicateNameFailsValidation (assertSessionHasErrors(['name']), assertDatabaseMissing) following the existing testCreatingTreatmentWithoutImageFailsValidation pattern (lines 53-65), plus a test confirming an update can keep a treatment's own unchanged name.

---
*Generated by Claude Runner*