### PR TITLE
Add regex format validation to appointment phone field

### DIFF
--- a/app/Http/Requests/AppointmentRequest.php
+++ b/app/Http/Requests/AppointmentRequest.php
@@ -39,7 +39,7 @@ class AppointmentRequest extends FormRequest
             'name'          => 'required|min:2|max:50',
             'email'         => 'required|email|min:5|max:100',
             'procedure'     => ['required', Rule::in($procedures)],
-            'phone'         => 'required|min:5|max:25',
+            'phone'         => 'required|min:5|max:25|regex:/^[0-9+\-\s()]+$/',
             'message'       => 'nullable|max:350',
             'opt_in'        => 'required|accepted',
         ];

--- a/tests/Feature/AppointmentControllerTest.php
+++ b/tests/Feature/AppointmentControllerTest.php
@@ -134,6 +134,16 @@ class AppointmentControllerTest extends TestCase
         Mail::assertNothingSent();
     }
 
+    public function testNonNumericPhoneFailsValidation()
+    {
+        Mail::fake();
+
+        $response = $this->post('/mail/appointment', $this->validPayload(['phone' => 'abcdefghij']));
+
+        $response->assertSessionHasErrors(['phone']);
+        Mail::assertNothingSent();
+    }
+
     public function testProcedureAcceptsAnExistingTreatmentName()
     {
         Mail::fake();


### PR DESCRIPTION
## TLDR
Add regex format validation to appointment phone field. Changed 2 file(s): +11/-1 lines.

## Plan
1) In app/Http/Requests/AppointmentRequest.php:30, change the phone rule to 'required|min:5|max:25|regex:/^[0-9+\-\s()]+$/' (allow digits, +, -, spaces, parentheses to cover NL formats like '06-12345678' or '+31 6 12345678'). 2) In tests/Feature/AppointmentControllerTest.php, add a new test method testNonNumericPhoneFailsValidation() mirroring the existing testInvalidProcedureFailsValidation() pattern (lines 92-100): post the validPayload() with phone overridden to a non-numeric string like 'abcdefghij', assert assertSessionHasErrors(['phone']), and Mail::assertNothingSent(). 3) Run `php artisan test --filter=AppointmentControllerTest` (or vendor/bin/phpunit) to confirm the new test passes and existing valid-phone tests (e.g. '0612345678' in validPayload()) still pass.

---
*Generated by Claude Runner*